### PR TITLE
Add new GA4 "auto" tracker for conversion events

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -51,6 +51,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m);}
         mkscrpt('https://www.googletagmanager.com/gtag/js?id={{ site.GA4 }}');
         mkscrpt('/assets/js/autotrack.js');
+        mkscrpt('/assets/js/buggytrack.js');
         (function(i,g,r){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();mkscrpt(g);
         })(window,'https://www.google-analytics.com/analytics.js','ga');
@@ -75,7 +76,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', '{{ site.GA4 }}');
+      gtag('config', '{{ site.GA4 }}', {'currency':'USD'});
 
       (function(w,d,t,r,u){var f,n,i;w[u]=w[u]||[],f=function(){var o={ti:"56243852"};o.q=w[u],w[u]=new UET(o),w[u].push("pageLoad")},n=d.createElement(t),n.src=r,n.async=1,n.onload=n.onreadystatechange=function(){var s=this.readyState;s&&s!=="loaded"&&s!=="complete"||(f(),n.onload=n.onreadystatechange=null)},i=d.getElementsByTagName(t)[0],i.parentNode.insertBefore(n,i)})(window,document,"script","//bat.bing.com/bat.js","uetq");
     }

--- a/assets/css/courselist.scss
+++ b/assets/css/courselist.scss
@@ -7,9 +7,13 @@ h3.courselink {
     margin-bottom: 0;
     background-color: $banner-color;
     color: white;
-    padding: 1rem;
+    padding: 0;
     letter-spacing: 3px;
     a {
+        display: inline-block;
+        height: 100%;
+        width: 100%;
+        padding: 1rem;
         color: white;
         text-decoration: underline;
         text-underline-offset: 2px;

--- a/assets/js/buggytrack.js
+++ b/assets/js/buggytrack.js
@@ -1,0 +1,83 @@
+const cyrb53 = function(str) {
+  // A simple string->integer hash function
+  // https://stackoverflow.com/a/52171480
+  let h1 = 0xdeadbeef ^ 0xabcd0123,
+    h2 = 0x41c6ce57 ^ 0xabcd0123;
+  for (let i = 0, ch; i < str.length; i++) {
+    ch = str.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  return 4294967296 * (2097151 & h2) + (h1 >>> 0);
+};
+const BuggyTracker = function (d) {
+  const tagr = /^\/tags\/([a-z-]+)[\/]?$/;
+  const courser = /^\/courses\/([a-z_-]+)[\/]?([a-z0-9_-]*)$/;
+  const blogr = /^\/blog\/20[2-7][0-9]\/[01][0-9]\/[0-3][0-9]\/[a-z_-]+$/;
+  const lp = d.createElement('a');
+  const whenceContent=function(referrer,r,l,m){
+    lp.href=referrer;l=d.location;
+    if (lp.host!=l.host) return null;
+    if (referrer) r=lp.pathname; else r='';
+    if (r == '/search/') return "search-results";
+    if (r == '/library/highlights') return "highlights";
+    if (r == '/content/random/') return "randomizer";
+    if (r == '/exclusive/') return "exclusive-content-list";
+    l = l.pathname; m = l.match(tagr) || r.match(tagr);
+    if(m) return m[1]+"-tag-page";
+    m = l.match(courser) || r.match(courser);
+    if(m) return m[1]+"-course";
+    m = l.match(blogr) || r.match(blogr);
+    if(m) return "blog-post";
+    m = r.match(/^\/content\/([a-z]+)\/$/);
+    if(m) return "master-"+m[1]+"-list";
+    m = r.match(/^\/content\/([a-z]+)\/([a-z0-9_-]+)$/);
+    if(m) return "related-content";
+    m = r.match(/^\/publishers\/([a-z-]+)$/);
+    if(m) return "publisher-page";
+    m = r.match(/^\/authors\/([a-z-]+)$/);
+    if(m) return "author-page";
+    m = r.match(/^\/series\/([a-z-]+)$/);
+    if(m) return "series-page";
+    m = r.match(/^\/journals\/([a-z-]+)$/);
+    if(m) return "journal-page";
+    return null;
+  };
+  const whenceLink=function(link,l,gp){
+    l=d.location.pathname; gp=link.parentElement.parentElement;
+    if(link.parentElement.className=='courselink' && l=='/courses/') return 'external-course-list';
+    if(link.className=='f3' && l=='/courses/') return 'mit-course-list';
+    if(gp.className=='social-media-list') return 'social-media-list';
+    if(gp.tagName=='UL' && l=='/sources/') return 'sources-list';
+    return null;
+  };
+  const getGAUID = function(){
+    try{return d.cookie.match(/_ga=(.+?);/)[1].split('.').slice(-2).join(".");}
+    catch(e){return null;}
+  };
+  this.getUID=function(){if(!this._uid){
+    this._uid = localStorage.getItem("uid") || getGAUID();
+    if(!this._uid){this._uid=Math.random()*10000000;localStorage.setItem("uid", this._uid);}
+    } return this._uid;
+  };
+  this.sendEvent=function(oid,value,list,category){gtag('event','purchase',{
+    transaction_id: "T_"+cyrb53(this.getUID()+":"+oid),
+    value: value,
+    items: [{
+      item_id: oid, price: value, item_category: category, item_list_id: list
+    }]
+  });};
+  this.handleEvent=function(e,link){link=e.target.closest('a');if(link && link.host != d.location.host) {
+    var cid = link.getAttribute('data-content-path');
+    var oid = cid || link.href;
+    var value = link.getAttribute('ga-event-value')*1 || 0.15;
+    if (localStorage.getItem(oid+":click")) value=0; else localStorage.setItem(oid+":click",1);
+    var list=null;if(cid){list=whenceContent(d.referrer);}else{list=whenceLink(link)}
+    if(value) this.sendEvent(oid,value,list,cid?'content-click':'link-click');
+  }};
+  d.addEventListener("click", this, {useCapture: true});
+  d.addEventListener("contextmenu", this, {useCapture: true, passive: true});
+}
+const buggytrack = new BuggyTracker(document);

--- a/courses.md
+++ b/courses.md
@@ -61,7 +61,7 @@ This site may use cookies to enhance your experience, but you can turn this off 
 {% assign bauthors = '' | split: '' %}
 {% for b in textbooks %}{% assign tbas = b.authors %}{% unless tbas.size > 3%}{% for tba in tbas %}{% unless bauthors contains tba %}{% assign bauthors = bauthors | push: tba %}{% endunless %}{% endfor %}{% endunless %}{% endfor %}
 {% capture onclick %}onclick="location.href='{{ course.url }}'"{% endcapture %}
-<h3 {{onclick}} class="courselink"><a href="{{ course.url }}">{{ course.title }}</a></h3>
+<h3 class="courselink"><a href="{{ course.url }}">{{ course.title }}</a></h3>
 <div class="coursedesc">
   <div class="descrow">
     <div {{onclick}} class="cicon"><i class="{{ course.icon }}"></i></div>
@@ -82,7 +82,7 @@ This site may use cookies to enhance your experience, but you can turn this off 
 Courses hosted on other websites.
 
 ### [The Arahant and the Four Noble Truths](https://agamaresearch.dila.edu.tw/wp-content/uploads/2014/06/lectures2012.htm){:ga-event-value="0.6"}
-{:onclick="goto('https://agamaresearch.dila.edu.tw/wp-content/uploads/2014/06/lectures2012.htm' ,0.6)" .courselink}
+{:.courselink}
 
 <div class="coursedesc">
   <div class="descrow">
@@ -93,7 +93,7 @@ Courses hosted on other websites.
 </div>
 
 ### [An Introduction to Classical Tibetan](http://www.nettletibetan.ca/){:ga-event-value="0.5"}
-{:onclick="goto('http://www.nettletibetan.ca/',0.5)" .courselink}
+{:.courselink}
 
 <div class="coursedesc">
   <div class="descrow">
@@ -105,7 +105,7 @@ Courses hosted on other websites.
 
 
 ### [Shin Buddhism in Modern Culture](http://bschawaii.org/shindharmanet/course/){:ga-event-value="1.5"}
-{:onclick="goto('http://bschawaii.org/shindharmanet/course/',1.5)" .courselink}
+{:.courselink}
 
 <div class="coursedesc">
   <div class="descrow">
@@ -116,7 +116,7 @@ Courses hosted on other websites.
 </div>
 
 ### [Human Behavioral Biology](https://youtube.com/playlist?list=PL848F2368C90DDC3D){:ga-event-value="3"}
-{:onclick="goto('https://youtube.com/playlist?list=PL848F2368C90DDC3D',3)" .courselink}
+{:.courselink}
 
 <div class="coursedesc">
   <div class="descrow">
@@ -127,7 +127,7 @@ Courses hosted on other websites.
 </div>
 
 ### [Modern and Contemporary American Poetry](https://www.coursera.org/learn/modpo){:ga-event-value="3"}
-{:onclick="goto('https://www.coursera.org/learn/modpo',3)" .courselink}
+{:.courselink}
 
 <div class="coursedesc">
   <div class="descrow">
@@ -139,7 +139,7 @@ Courses hosted on other websites.
 </div>
 
 ### [The Making of Modern Ukraine](https://youtube.com/playlist?list=PLh9mgdi4rNewfxO7LhBoz_1Mx1MaO6sw_){:ga-event-value="2"}
-{:onclick="goto('https://youtube.com/playlist?list=PLh9mgdi4rNewfxO7LhBoz_1Mx1MaO6sw_',2)" .courselink}
+{:.courselink}
 
 <div class="coursedesc">
   <div class="descrow">


### PR DESCRIPTION
GA4 auto tracks clicks, etc. BUT it gives no way to associate these events with an event value a la UA+autotrack.  Since this is a step back from the "Auto" I've named it "Horse and Buggy" tracker... or just "BuggyTrack" for short.  It registers "purchase" events for each click that has a monetary value associated with it.

In the future, I plan to add more subcategory data and additional purchase events for other conversion events such as AV playback.