### PR TITLE
Add ebooklib to requirements.txt

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -16,3 +16,4 @@ titlecase
 pypdf
 Mastodon.py
 atproto
+ebooklib


### PR DESCRIPTION
The codebase uses `ebooklib` in `epubutils.py` for handling EPUB files, but this dependency is not listed in requirements.txt. This PR adds ebooklib to ensure all dependencies are properly declared.

**Changes:**
- Added `ebooklib` to requirements.txt

**Rationale:**
- Prevents ModuleNotFoundError when running scripts that handle EPUB files (e.g. android_go_through.py)
- Ensures all dependencies can be installed with a single `pip install -r requirements.txt` command
- Improves developer experience by documenting all required dependencies

**Testing:**
- Verified that `pip install -r requirements.txt` successfully installs ebooklib
- Confirmed that scripts using epubutils.py can run without import errors