### PR TITLE
add: searchBySutta and TDD && suttaNumOnly Array

### DIFF
--- a/assets/js/search_functions.js
+++ b/assets/js/search_functions.js
@@ -2,6 +2,7 @@
 var BMAX = 250; // Max blurb size in characters
 var RMAX = 100; // Max number of results to display
 var joinedTitles = []
+var suttaNumOnly = []
 
 function normalizeSuttaTitles (obj) {
   var joinedTitleDatabase = []
@@ -10,7 +11,7 @@ function normalizeSuttaTitles (obj) {
     const item = obj[i];
     if (!item || item.type !== "content" || item.category !== "canon") continue;
     const title = item.title || "";
-      const titleJoin = title.normalize("NFD").replace(/[\u0300-\u036f]/g, "").replace(/^\s*(?:DN|MN|SN|AN|KN|LAL|DA|MA|SA|EA|SNP|DHP|ITI|THAG|THIG|UD|NIDD|CV|BV|AP|JA|PV|VV|KP|PTS)\s*\d+(?:\.\d+)?\s*[:.-]?\s*/i, "").replace(/\s*[:\-–]\s*.*$/, "").toLowerCase().replace(/[^a-z0-9]/g, "");
+      const titleJoin = title.normalize("NFD").replace(/[\u0300-\u036f]/g, "").replace(/^\s*(?:DN|MN|SN|AN|KN|LAL|DA|MA|SA|EA|SNP|DHP|ITI|THAG|THIG|UD|NIDD|CV|BV|AP|JA|PV|VV|KP|PTS|KHP|MV|T|MVU|VB|THAAP|SF)\s*\d+(?:\.\d+)?\s*[:.-]?\s*/i, "").replace(/\s*[:\-–]\s*.*$/, "").toLowerCase().replace(/[^a-z0-9]/g, "");
       const removedTheOnJoin = titleJoin.replace(/^\s*(?:the)\s*/i, "");
       if(removedTheOnJoin.includes('sutta') || removedTheOnJoin.includes('sutra') || removedTheOnJoin.includes('gatha')) {
         joinedTitleDatabase.push({
@@ -21,6 +22,27 @@ function normalizeSuttaTitles (obj) {
     }
   }
   return joinedTitleDatabase;
+}
+
+function storeSuttaNumsOnly (obj) {
+  var suttaNumDatabase = []
+
+  for (var i in obj){
+    const item = obj[i];
+    if (!item || item.type !== "content" || item.category !== "canon") continue;
+    const title = item.title || "";
+      const titleJoin = title.replace(
+        /^((?:DN|MN|SN|AN|KN|LAL|DA|MA|SA|EA|SNP|DHP|ITI|THAG|THIG|UD|NIDD|CV|BV|AP|JA|PV|VV|KP|PTS|KHP|MV|T|MVU|VB|THAAP|SF)\s*\d+(?:\.\d+)?).*/i,
+        "$1"
+      ).replace(/\./g, "").replace(/\s/g, "").toLowerCase()
+
+      suttaNumDatabase.push({
+        ref: i,
+        title: titleJoin,
+        matchData: { metadata: {} }
+      });
+  }
+  return suttaNumDatabase;
 }
 
 function getPositions(result, field) {
@@ -206,6 +228,22 @@ function findOneWordSuttaTitleMatches(query, joinedTitles) {
   return tokenResults;
 }
 
+function searchBySuttaNum (query, suttaNumOnly) {
+  var tokenResults = [];
+  const normalizedQuery = query.normalize("NFD").replace(/[\u0300-\u036f]/g, "").replace(/[^a-z0-9]/g, "").replace(/\./g, "").replace(/\s+/g, "").replace(" ", "").toLowerCase();
+  for (var i in suttaNumOnly){
+    const item = suttaNumOnly[i]
+    if(item.title === normalizedQuery){
+      tokenResults.push({
+        ref: item.ref,
+        score: 1,
+        matchData: { metadata: {} }
+      });
+    }
+  }
+  return tokenResults;
+}
+
 function handleSearchMessage(data, searchFn) {
   var results = [];
   var warning = "";
@@ -251,7 +289,14 @@ function handleSearchMessage(data, searchFn) {
       });
     });
   }
-  finalResults = results.length ? results : findOneWordSuttaTitleMatches(data.q.trim(), joinedTitles);
+
+  let hasNumber = /\d/.test(data.q.trim());
+
+  if(hasNumber){
+    finalResults = searchBySuttaNum(data.q.trim(), suttaNumOnly);
+    warning = "";
+  } else finalResults = results.length ? results : findOneWordSuttaTitleMatches(data.q.replace(/\s+/g, "").replace(" ","").trim(), joinedTitles);
+
   return {
     "warninghtml": warning,
     "html": displaySearchResults(finalResults),

--- a/assets/js/search_index.js
+++ b/assets/js/search_index.js
@@ -70,6 +70,8 @@ var idx = lunr(function () {
 });
 
 joinedTitles = normalizeSuttaTitles(store);
+suttaNumOnly = storeSuttaNumsOnly(store);
+console.log(suttaNumOnly);
 
 self.onmessage = function(e) {
   self.postMessage(handleSearchMessage(e.data, idx.search.bind(idx)));

--- a/assets/js/tests/search-worker.test.js
+++ b/assets/js/tests/search-worker.test.js
@@ -70,7 +70,9 @@ vm.runInContext(
   'this.addMatchHighlights = addMatchHighlights;\n' +
   'this.getBlurbForResult = getBlurbForResult;\n' +
   'this.normalizeSuttaTitles = normalizeSuttaTitles;\n' +
+  'this.storeSuttaNumsOnly = storeSuttaNumsOnly;\n' +
   'this.findOneWordSuttaTitleMatches = findOneWordSuttaTitleMatches;\n' +
+  'this.searchBySuttaNum = searchBySuttaNum;\n' +
   'this.handleSearchMessage = handleSearchMessage;\n' +
   'this.displaySearchResults = displaySearchResults;\n',
   sandbox
@@ -78,7 +80,7 @@ vm.runInContext(
 
 const {
   categoryName, getPositions, resultMatched,
-  addMatchHighlights, getBlurbForResult, oneWordToken, normalizeSuttaTitles, findOneWordSuttaTitleMatches, handleSearchMessage
+  addMatchHighlights, getBlurbForResult, oneWordToken, normalizeSuttaTitles, storeSuttaNumsOnly, findOneWordSuttaTitleMatches, searchBySuttaNum, handleSearchMessage
 } = sandbox;
 
 // ── categoryName ────────────────────────────────────────────────────
@@ -405,8 +407,6 @@ describe('normalizeSuttaTitles', () => {
     const result = normalizeSuttaTitles(mockStore);
     assert.equal(result.length, 0);
   });
-
-
 });
 
 // ── findOneWordSuttaTitleMatches ─────────────────────────────────────────────
@@ -417,6 +417,48 @@ describe('findOneWordSuttaTitleMatches', () => {
     };
     const result = findOneWordSuttaTitleMatches('culasaccakasutta', mockStore);
     assert.equal(toLocal(result).length, 1);
+  });
+});
+
+// ── storeSuttaNumsOnly ─────────────────────────────────────────────
+describe('storeSuttaNumsOnly', () => {
+  it('returns an array of database objects with only nikaya index as title', () => {
+    const mockStore = {
+      id1: {
+        title: 'AN 9.44 Paññā Vimutta Sutta: Freed by Wisdom',
+        type: 'content',
+        category: 'canon'
+      },
+      id2: {
+        title: 'Thig 14.1 Subhājīvakambavanikā Therīgāthā: Subhā of Jīvaka’s Mango Grove',
+        type: 'content',
+        category: 'canon'
+      }
+    };
+    const result = storeSuttaNumsOnly(mockStore);
+    assert.equal(result.length, 2);
+    assert.equal(result[0].ref, 'id1');
+    assert.equal(result[0].title, 'an944');
+    assert.equal(result[1].ref, 'id2');
+    assert.equal(result[1].title, 'thig141');
+  });
+});
+
+// ── searchBySuttaNum ─────────────────────────────────────────────
+describe('searchBySuttaNum', () => {
+  it('checks query with number, against dataset of nikaya indexes', () => {
+    const mockStore = {
+      'id1': { title: 'an944', type: 'content', category: 'canon' },
+      'id2': {
+        title: 'thig141',
+        type: 'content',
+        category: 'canon'
+      }
+    };
+    const result = searchBySuttaNum('an 9.44', mockStore);
+    const result2 = searchBySuttaNum('thig 14.1', mockStore);
+    assert.equal(toLocal(result).length, 1);
+    assert.equal(toLocal(result2).length, 1);
   });
 });
 


### PR DESCRIPTION
Added functionality for searching nikaya references indefinitely.

We have 2 functions and a new array. StoreSuttaNumsOnly which stores objects in an array called suttaNumOnly. 
Then we detect whether or not the user has input a number, then run searchBySuttaNum function. Just like how we handled joinsuttatitles but for nikaya indexes only this time.

This may have implications for other types of content with numbers. Maybe you can review this and help me understand how to make this feature better.

Although I have realized, a lot of our content titles use words for numbers - like one, six, twenty. if this is consistent, then this method might be perfectly fine.