### PR TITLE
Fix Markdown formatting in from-book paper footers

### DIFF
--- a/_layouts/content.html
+++ b/_layouts/content.html
@@ -77,7 +77,7 @@ layout: default
     {%- if page.from_book -%}
       {%- assign fbook = site.content | where: "slug", page.from_book | where: "category", "monographs" | first -%}
       {%- if fbook -%}
-        {% capture booktitle %}<a href="{{ fbook.url }}">{{ fbook.title }}</a>{% endcapture %}
+        {% capture booktitle %}<a href="{{ fbook.url }}">{{ fbook.title | markdownify | remove: '<p>' | remove: '</p>' }}</a>{% endcapture %}
       {%- endif -%}
     {%- endif -%}
     {% if page.series %}{% assign series = site.series | find: "slug", page.series %}{% else %}{% assign series = nil %}{% endif %}


### PR DESCRIPTION
## Summary

Render the `from-book` title through the existing `markdownify` filter before wrapping it in emphasis. This keeps Markdown-formatted book titles consistent with the other paper metadata.

## Testing

- `npm test` (70 passed)
- production Jekyll 4.4.1 build
- generated-page oracle: one `<em>` element and no literal `*Saṃyutta Nikāya*`

Fixes #658
